### PR TITLE
Fail Fast When Unsupported Non-Pure Python Types Are Encountered

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module '@fridgerator/pynode' {
+declare module '@amcquistan/pynode' {
   /**
    * Fixes dyanmic linking issue in python
    * @param dlFile Python shared library file name
@@ -38,7 +38,7 @@ declare module '@fridgerator/pynode' {
    * def add(a, b):
    *   return a + b
    *
-   * const pynode = require('@fridgerator/pynode')
+   * const pynode = require('@amcquistan/pynode')
    * pynode.startInterpreter()
    * pynode.openFile('test')
    * let x = pynode.call('add', 1, 2)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module '@amcquistan/pynode' {
+declare module '@fridgerator/pynode' {
   /**
    * Fixes dyanmic linking issue in python
    * @param dlFile Python shared library file name
@@ -38,7 +38,7 @@ declare module '@amcquistan/pynode' {
    * def add(a, b):
    *   return a + b
    *
-   * const pynode = require('@amcquistan/pynode')
+   * const pynode = require('@fridgerator/pynode')
    * pynode.startInterpreter()
    * pynode.openFile('test')
    * let x = pynode.call('add', 1, 2)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,8 +83,9 @@ void Call(const Nan::FunctionCallbackInfo<v8::Value> &args)
       } 
       else 
       {
+        std::string errMsg = std::string("Unsupported type returned (") + pValue->ob_type->tp_name + std::string("), only pure Python types are supported.");
         Py_DECREF(pValue);
-        Nan::ThrowError("Unsupported type returned (" + pValue->ob_type->tp_name + "), only pure Python types are supported.");
+        return Nan::ThrowTypeError(Nan::New(errMsg).ToLocalChecked());
       }
       Py_DECREF(pValue);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,11 @@ void Call(const Nan::FunctionCallbackInfo<v8::Value> &args)
       {
         auto obj = BuildV8Dict(pValue);
         args.GetReturnValue().Set(obj);
+      } 
+      else 
+      {
+        Py_DECREF(pValue);
+        Nan::ThrowError("Unsupported type returned (" + pValue->ob_type->tp_name + "), only pure Python types are supported.");
       }
       Py_DECREF(pValue);
     }


### PR DESCRIPTION
If an unsupported python type is encountered then throw a Nan::ThrowTypeError back up to JS 

As an example, if you have a python function returning a numpy.ndarray like this

```
def test_numpy():
    import numpy as np
    return np.array([1,2,3])
```

and are calling `test_numpy` from Node like this

```
  new Promise((resolve, reject) => {
      try {
        pynode.call('test_numpy')
        resolve("all good");
      } catch(err) {
        console.log(err);
        reject('failed');
      }
  })
```

The following exception error is thrown and will be logged to the console

```
TypeError: Unsupported type returned (numpy.ndarray), only pure Python types are supported.
    at Promise (/Users/adammcquistan/Code/javascript/pynode/server.js:24:16)
    at new Promise (<anonymous>)
    at app.get (/Users/adammcquistan/Code/javascript/pynode/server.js:22:3)
    at Layer.handle [as handle_request] (/Users/adammcquistan/Code/javascript/pynode/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/adammcquistan/Code/javascript/pynode/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/Users/adammcquistan/Code/javascript/pynode/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/Users/adammcquistan/Code/javascript/pynode/node_modules/express/lib/router/layer.js:95:5)
    at /Users/adammcquistan/Code/javascript/pynode/node_modules/express/lib/router/index.js:281:22
    at Function.process_params (/Users/adammcquistan/Code/javascript/pynode/node_modules/express/lib/router/index.js:335:12)
    at next (/Users/adammcquistan/Code/javascript/pynode/node_modules/express/lib/router/index.js:275:10)
(node:89831) UnhandledPromiseRejectionWarning: TypeError: res.err is not a function
    at Promise.then.catch.err (/Users/adammcquistan/Code/javascript/pynode/server.js:36:21)
    at <anonymous>
    at runMicrotasksCallback (internal/process/next_tick.js:121:5)
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```