### PR TITLE
Thread safe

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -134,7 +134,7 @@ PyObject *BuildPyArray(v8::Local<v8::Value> arg)
   return list;
 }
 
-PyObject *BuildPyArgs(const Nan::FunctionCallbackInfo<v8::Value> &args)
+PyObject *BuildPyArgs(const v8::FunctionCallbackInfo<v8::Value>& args)
 {
   // Arguments length minus 2: one for function name, one for js callback
   PyObject *pArgs = PyTuple_New(args.Length() - 2);

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -7,7 +7,7 @@
 // v8 to Python
 PyObject *BuildPyArray(v8::Local<v8::Value> arg);
 PyObject *BuildPyDict(v8::Local<v8::Value> arg);
-PyObject *BuildPyArgs(const Nan::FunctionCallbackInfo<v8::Value> &args);
+PyObject *BuildPyArgs(const v8::FunctionCallbackInfo<v8::Value>& args);
 
 // Python to v8
 v8::Local<v8::Array> BuildV8Array(PyObject *obj);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,6 +81,9 @@ void startInterpreter(const v8::FunctionCallbackInfo<v8::Value>& info)
 
   int isInitialized = Py_IsInitialized();
   if (isInitialized == 0) Py_Initialize();
+
+  int threadsInitialized = PyEval_ThreadsInitialized();
+  if (threadsInitialized == 0) PyEval_InitThreads();
 }
 
 void stopInterpreter(const v8::FunctionCallbackInfo<v8::Value>& info)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,3 @@
-// #include <mutex>
 #include <sstream>
 #include <Python.h>
 #include <frameobject.h>
@@ -20,7 +19,6 @@ class py_context
 public:
     py_context()
     {
-      // std::unique_lock<std::mutex>(pyContextLock);
       gstate = PyGILState_Ensure();
     }
 
@@ -30,7 +28,6 @@ public:
     }
 
 private:
-    // static std::mutex pyContextLock;
     PyGILState_STATE gstate;
 };
 
@@ -112,14 +109,11 @@ void appendSysPath(const Nan::FunctionCallbackInfo<v8::Value> &args)
   appendPathStr = (char *)malloc(len + 1);
   snprintf(appendPathStr, len + 1, "import sys;sys.path.append(r\"%s\")", *pathName);
 
-  // PyGILState_STATE gstate;
-  // gstate = PyGILState_Ensure();
   {
     py_context ctx;
     PyRun_SimpleString(appendPathStr);
     free(appendPathStr);
   }
-  // PyGILState_Release(gstate);
 }
 
 void openFile(const v8::FunctionCallbackInfo<v8::Value>& info)
@@ -134,8 +128,6 @@ void openFile(const v8::FunctionCallbackInfo<v8::Value>& info)
 
   Nan::Utf8String fileName(info[0]);
 
-  // PyGILState_STATE gstate;
-  // gstate = PyGILState_Ensure();
   {
     py_context ctx;
 
@@ -153,8 +145,6 @@ void openFile(const v8::FunctionCallbackInfo<v8::Value>& info)
       return;
     }
   }
-
-  // PyGILState_Release(gstate);
 }
 
 void eval(const Nan::FunctionCallbackInfo<v8::Value> &args)
@@ -173,10 +163,8 @@ class CallWorker : public Nan::AsyncWorker {
   public:
     CallWorker(Nan::Callback *callback, PyObject *pyArgs, PyObject *pFunc)
       : Nan::AsyncWorker(callback), pyArgs(pyArgs), pFunc(pFunc) {
-        // gstate = PyGILState_Ensure();
       }
     ~CallWorker() {
-      // PyGILState_Release(gstate);
     }
     
     void Execute () {
@@ -303,14 +291,12 @@ class CallWorker : public Nan::AsyncWorker {
         }
       }
 
-      // PyGILState_Release(gstate);
       callback->Call(2, argv);
     }
   
   private:
     PyObject *pyArgs;
     PyObject *pFunc;
-    // PyGILState_STATE gstate;
 };
 
 void call(const v8::FunctionCallbackInfo<v8::Value>& info) {
@@ -325,9 +311,6 @@ void call(const v8::FunctionCallbackInfo<v8::Value>& info) {
   }
 
   Nan::Utf8String functionName(info[0]);
-
-  // PyGILState_STATE gstate;
-  // gstate = PyGILState_Ensure();
 
   PyNodeData* data =
       reinterpret_cast<PyNodeData*>(info.Data().As<v8::External>()->Value());
@@ -362,8 +345,6 @@ void call(const v8::FunctionCallbackInfo<v8::Value>& info) {
       Nan::ThrowError("Could not find function name / function not callable");
     }
   }
-
-  // PyGILState_Release(gstate);
 
   Nan::AsyncQueueWorker(new CallWorker(
     new Nan::Callback(Nan::To<v8::Function>(info[info.Length() - 1]).ToLocalChecked()),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@ class py_context
 public:
     py_context()
     {
-      // std::unique_lock<std::mutex>(pyContextLock);
+      std::unique_lock<std::mutex>(pyContextLock);
       gstate = PyGILState_Ensure();
     }
 
@@ -30,6 +30,7 @@ public:
     }
 
 private:
+    static std::mutex pyContextLock;
     PyGILState_STATE gstate;
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -287,6 +287,11 @@ void call(const v8::FunctionCallbackInfo<v8::Value>& info) {
     return;
   }
 
+  if (!info[info.Length() - 1]->IsFunction()) {
+    Nan::ThrowError("Last argument to 'call' must be a function");
+    return;
+  }
+
   PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-#include <mutex>
+// #include <mutex>
 #include <sstream>
 #include <Python.h>
 #include <frameobject.h>
@@ -20,7 +20,7 @@ class py_context
 public:
     py_context()
     {
-      std::unique_lock<std::mutex>(pyContextLock);
+      // std::unique_lock<std::mutex>(pyContextLock);
       gstate = PyGILState_Ensure();
     }
 
@@ -30,7 +30,7 @@ public:
     }
 
 private:
-    static std::mutex pyContextLock;
+    // static std::mutex pyContextLock;
     PyGILState_STATE gstate;
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ class PyNodeData {
   private:
     static void DeleteMe(const v8::WeakCallbackInfo<PyNodeData>& info) {
       delete info.GetParameter();
-      fprintf(stderr, "delte me\n");
+      fprintf(stderr, "delete me\n");
     }
 
     v8::Persistent<v8::Object> exports_;

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ const expect = chai.expect
 const nodePython = require('./build/Release/PyNode')
 const { promisify } = require('util')
 
-nodePython.dlOpen('libpython3.6m.so')
+if (process.platform === 'linux') nodePython.dlOpen('libpython3.6m.so')
 nodePython.startInterpreter()
 nodePython.appendSysPath('./test_files')
 nodePython.openFile('tools')

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ const { promisify } = require('util')
 nodePython.dlOpen('libpython3.6m.so')
 nodePython.startInterpreter()
 nodePython.appendSysPath('./test_files')
-nodePython.openFile("tools")
+nodePython.openFile('tools')
 
 const call = promisify(nodePython.call)
 

--- a/test.js
+++ b/test.js
@@ -25,6 +25,14 @@ describe('nodePython', () => {
   })
 
   describe('#call', () => {
+    it('should fail if the last parameter is not a function', () => {
+      try {
+        nodePython.call('return_immediate', 2)
+      } catch (err) {
+        expect(err.message).to.equal("Last argument to 'call' must be a function")
+      }
+    })
+
     it('should return the stack trace', done => {
       call('causes_runtime_error')
         .then(result => console.log('should not see this : ', result))

--- a/test_files/performance.py
+++ b/test_files/performance.py
@@ -10,19 +10,21 @@
 from math import pow, atan, tan
 import multiprocessing
 
+queue = multiprocessing.Queue()
+
 def job(queue, num1, num2):
   base = num1 + num2
   result = 0
   for i in range(int(pow(base, 7))):
     result += atan(i) * tan(i)
   print("result : ", result, flush=True)
-  queue.put(result)
+  queue.put_nowait(result)
 
 def generate_slow_number(num1, num2):
-  queue = multiprocessing.Queue()
+  global queue
   p = multiprocessing.Process(target=job, args=(queue, num1, num2, ))
   p.start()
-  x = queue.get()
+  x = queue.get(block=True)
   p.join()
   print("return x : ", x, flush=True)
   return x

--- a/test_files/performance.py
+++ b/test_files/performance.py
@@ -1,7 +1,8 @@
 from math import pow, atan, tan
 
-def generate_slow_number(base):
+def generate_slow_number(num1, num2):
+  base = num1 + num2
   result = 0
-  for i in range(int(pow(12, 7))):
+  for i in range(int(pow(base, 7))):
     result += atan(i) * tan(i)
   return result

--- a/test_files/performance.py
+++ b/test_files/performance.py
@@ -1,8 +1,28 @@
-from math import pow, atan, tan
+# from math import pow, atan, tan
 
-def generate_slow_number(num1, num2):
+# def generate_slow_number(num1, num2):
+#   base = num1 + num2
+#   result = 0
+#   for i in range(int(pow(base, 7))):
+#     result += atan(i) * tan(i)
+#   return result
+
+from math import pow, atan, tan
+import multiprocessing
+
+def job(queue, num1, num2):
   base = num1 + num2
   result = 0
   for i in range(int(pow(base, 7))):
     result += atan(i) * tan(i)
-  return result
+  print("result : ", result, flush=True)
+  queue.put(result)
+
+def generate_slow_number(num1, num2):
+  queue = multiprocessing.Queue()
+  p = multiprocessing.Process(target=job, args=(queue, num1, num2, ))
+  p.start()
+  x = queue.get()
+  p.join()
+  print("return x : ", x, flush=True)
+  return x

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,29 @@
+const { parentPort } = require('worker_threads')
+const pynode = require('./build/Release/PyNode')
+
+pynode.startInterpreter()
+    pynode.appendSysPath('./test_files')
+    pynode.openFile('performance')
+const longRunningFunction = () => {
+  return new Promise((resolve, reject) => {
+    console.log('cwd : ', process.cwd())
+    
+    pynode.call('generate_slow_number', 5, 7, (err, result) => {
+      if (err) {
+        reject(err)
+        return
+      }
+      resolve(result)
+    })
+  })
+}
+
+longRunningFunction()
+  .then(result => {
+    console.log('result : ', result)
+    parentPort.postMessage(result)
+  })
+  .catch(e => {
+    console.log('err : ', e)
+    parentPort.postMessage({error: e})
+  })

--- a/worker_test.js
+++ b/worker_test.js
@@ -1,0 +1,42 @@
+const { Worker, isMainThread, parentPort, workerData } = require('worker_threads')
+
+const TIMEOUT = 1000
+
+const threadCount = 1
+const threads = new Set()
+for (let i = 0; i < threadCount; i++) {
+  setTimeout(() => {
+    threads.add(
+      new Worker('/home/nick/Code/Personal/PyNode/worker.js')
+    )
+  }, i  * TIMEOUT)
+}
+
+setTimeout(() => {
+  console.log('threads : ', threads.size)
+  for (let worker of threads) {
+    worker.on('message', msg => {
+      console.log('msg : ', msg)
+    })
+    worker.on('error', err => {
+      console.log('worker err : ', err)
+      threads.delete(worker)
+      if (threads.size === 0) {
+        console.log('done')
+        process.exit(0)
+      }
+    })
+    worker.on('exit', () => {
+      console.log('worker done')
+      threads.delete(worker)
+      if (threads.size === 0) {
+        console.log('done')
+        process.exit(0)
+      }
+    })
+  }
+}, (threadCount * TIMEOUT) + 100)
+
+setInterval(() => {
+  console.log('.')
+}, 1000)

--- a/worker_test.js
+++ b/worker_test.js
@@ -7,7 +7,7 @@ const threads = new Set()
 for (let i = 0; i < threadCount; i++) {
   setTimeout(() => {
     threads.add(
-      new Worker('/home/nick/Code/Personal/PyNode/worker.js')
+      new Worker(`${process.cwd()}/worker.js`)
     )
   }, i  * TIMEOUT)
 }

--- a/worker_test.js
+++ b/worker_test.js
@@ -2,7 +2,7 @@ const { Worker, isMainThread, parentPort, workerData } = require('worker_threads
 
 const TIMEOUT = 1000
 
-const threadCount = 1
+const threadCount = 2
 const threads = new Set()
 for (let i = 0; i < threadCount; i++) {
   setTimeout(() => {


### PR DESCRIPTION
Use `PyGILState_Ensure` and `PyGILState_Release` methods around all python calls.  This allows pynode to be called from mutliple threads.