### PR TITLE
Updated binding.gyp to work correctly on Linux

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -43,15 +43,11 @@
           }
         }],
         ['OS!="win"', {
-          "variables": {
-            "PY_INCLUDE%": "<!(if [ -z \"$PY_INCLUDE\" ]; then echo $(python-config --includes); else echo $PY_INCLUDE; fi)",\
-            "PY_LIBS%": "<!(if [ -z \"$PY_LIBS\" ]; then echo $(python-config --ldflags); else echo $PY_LIBS; fi)"
-          },
           "include_dirs": [
-            "<(PY_INCLUDE)"
+            "<!(python3-config --includes | sed 's/-I//g' | sed 's/ .*//g')"
           ],
-          "libraries": [
-            "<(PY_LIBS)",
+          "ldflags": [
+            "<!(python3-config --ldflags)",
           ]
         }]
       ]


### PR DESCRIPTION
The original version of binding.gyp caused all sorts of problems due to not parsing the output of python-config correctly. This fixes that.