### PR TITLE
Wrapped Python objects in JS and wrapped JS objects in Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,20 @@
 
 **Node v10 or above is required**
 
-**Only tested with python 3.6.x and python 3.7.x.  Probably wont work with Python 2.7**
+**Tested with python 3.6 - 3.8.**
 
 ## Installation
 
 **BEFORE NPM INSTALL OR YARN INSTALL**
 
-* Make sure `python` in your system `PATH` is the correct one: `python --version`
-* **Linux and Mac only**: make sure `python-config` is also in your path and is from the correct python installation.  You may have to symlink `python3-config` to `/usr/local/bin`.
+* Make sure `python` in your system `PATH` is the correct one: `python --version`. You may use a virtualenv to do this.
+* Install gyp-next: `git clone https://github.com/nodejs/gyp-next`; `cd gyp-next`; `python setup.py install`
 * `yarn add @fridgerator/pynode` or
 `npm install @fridgerator/pynode`
 
 ## Usage
+
+### Async API
 
 In a python file `test.py`:
 
@@ -49,4 +51,119 @@ pynode.call('add', 1, 2, (err, result) => {
   if (err) return console.log('error : ', err)
   result === 3 // true
 })
+```
+
+### Full Object API
+
+The Full Object API allows full interaction between JavaScript objects within Python code, and Python objects within JavaScript code. In Python, this works very transparently without needing to know if a value is a Python or JS object. In JavaScript, the interface is (currently) a bit more primitive, but supports getting object members and calling objects using `.get()` and `.call()`.
+
+Primitives are generally converted between JS and Python values, so passing strings, numbers, lists, and dicts generally works as expected. The wrappers described above only kick in for non-primitives.
+
+In a python file `test_files/objects.py`:
+
+```python
+
+def does_things_with_js(jsobject):
+    '''This function demonstrates that we can treat passed-in
+    JavaScript objects (almost) as if they were native Python objects.
+    '''
+    # We can print out JS objects; toString is called automatically
+    # (it is mapped to Python's __str__):
+    print("does_things_with_js:", jsobject)
+    
+    # We can call any function on the JS object. Objects passed
+    # in are converted to JS if they are primitives, or wrapped in the
+    # Full Object API if not, so JavaScript can also call back into Python:
+    result = jsobject.arbitraryFunction("nostrongtypinghere")
+    
+    # The result from JavaScript is also converted back into Python:
+    print(result)
+    
+    # The result will be converted back into JavaScript by PyNode:
+    return result
+
+class PythonClass(object):
+    '''A simple class to demonstrate creating and calling an instance from JavaScript.'''
+
+    def __init__(self, a, b):
+        '''Constructor. a and b are converted to Python types by PyNode'''
+        self.a = a
+        self.b = b
+
+    def collate(self, callback):
+        '''A function that is given a callback to call into. This can be a JavaScript function'''
+        print('PythonClass.collate()')
+        print('callback:', callback)
+	
+	# Arguments are converted into JavaScript objects, and the return value
+	# from the callback is converted back into Python objects.
+        return callback(self.a, self.b, "hello", 4)
+
+    def __repr__(self):
+        return 'PythonClass(a=%r, b=%r)' % (self.a, self.b)
+
+```
+
+In Node:
+
+```javascript
+const pynode = require('@fridgerator/pynode')
+
+pynode.startInterpreter();
+pynode.appendSysPath('./test_files/');
+
+/* Modules are imported as JS objects, implementing the Full Object API */
+const objectsmodule = pynode.import('objects'); /* test module in test_files */
+const python_builtins = pynode.import('builtins'); /* access to python builtins such as str, all, etc, if you want them. */
+
+/* Define an example JavaScript class: */
+class JSClass {
+    constructor(item) {
+        this.item = item
+    }
+    arbitraryFunction(value) {
+        console.log("arbitraryFunction called; item = " + this.item);
+        console.log("                         value = " + value);
+        return value + 12;
+    }
+    toString() {
+        return "JSClass{item=" + this.item + "}"
+    }
+}
+
+/* Create an instance of JSClass which Python will have access to: */
+jsclassinstance = new JSClass(['some', 'data']);
+console.log(jsclassinstance);
+
+/* Get the 'does_things_with_js' Python function from the objects module,
+   and call it, passing in the JSClass object: */
+result = objectsmodule.get('does_things_with_js').call(jsclassinstance);
+
+/* Python objects are automatically converted back to JS, or returned as
+   PyNodeWrappedPythonObject instances (see below( if they are
+   non-primitive types:
+*/
+console.log(result);
+
+/* Create a Python class. In Python this is done by calling the class
+   object with constructor arguments (ie, don't use `new`): */
+somedict = {'some': 'dict'};
+pyclassinstance = objectsmodule.get('PythonClass').call(somedict, '2');
+
+/* The resulting object is returned as a PyNodeWrappedPythonObject instance,
+   which implements the Full Object API: */
+console.log(pyclassinstance);
+
+/* The PyNodeWrappedPythonObject instance can have members retrieved from it
+   and functions called. Below is the equivalent of (in Python) 
+   `getattr(pyclassinstance, 'collate').__call__(<some javascript function>)`
+   or put simply:
+   `pyclassinstance.collate(<some javascript function>)`.
+   The JavaScript function is also converted to a callable Python object */
+*/
+result = pyclassinstance.get('collate').call(function(a, b, c, d) {
+    console.log(arguments);
+    return c * d; /* JavaScript return values are converted back to Python types by PyNode */
+});
+console.log(result);
 ```

--- a/binding.gyp
+++ b/binding.gyp
@@ -48,8 +48,8 @@
         }],
         ['OS!="win"', {
           "variables": {
-            "PY_INCLUDE%": "<!(if [ -z \"$PY_INCLUDE\" ]; then echo $(python-config --includes); else echo $PY_INCLUDE; fi)",\
-            "PY_LIBS%": "<!(if [ -z \"$PY_LIBS\" ]; then echo $(python-config --ldflags); else echo $PY_LIBS; fi)"
+            "PY_INCLUDE%": "<!(if [ -z \"$PY_INCLUDE\" ]; then echo $(python build_include.py); else echo $PY_INCLUDE; fi)",\
+            "PY_LIBS%": "<!(if [ -z \"$PY_LIBS\" ]; then echo $(python build_ldflags.py); else echo $PY_LIBS; fi)"
           },
           "include_dirs": [
             "<(PY_INCLUDE)"

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,8 @@
         "src/main.cpp",
         "src/helpers.cpp",
         "src/pynode.cpp",
-        "src/worker.cpp"
+        "src/worker.cpp",
+        "src/pywrapper.cpp"
       ],
       'include_dirs': [
         "<!@(node -p \"require('node-addon-api').include\")"

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,7 +7,8 @@
         "src/helpers.cpp",
         "src/pynode.cpp",
         "src/worker.cpp",
-        "src/pywrapper.cpp"
+        "src/pywrapper.cpp",
+        "src/jswrapper.c"
       ],
       'include_dirs': [
         "<!@(node -p \"require('node-addon-api').include\")"

--- a/binding.gyp
+++ b/binding.gyp
@@ -16,6 +16,8 @@
       'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
+      'cflags+': [ '-g' ],
+      'cflags_cc+': [ '-g' ],
       'xcode_settings': {
         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
         'CLANG_CXX_LIBRARY': 'libc++',

--- a/build_include.py
+++ b/build_include.py
@@ -1,0 +1,6 @@
+import sysconfig
+
+flags = ['-I' + sysconfig.get_path('include'),
+         '-I' + sysconfig.get_path('platinclude')]
+print(' '.join(flags))
+

--- a/build_ldflags.py
+++ b/build_ldflags.py
@@ -1,0 +1,19 @@
+import sys
+import sysconfig
+
+pyver = sysconfig.get_config_var('VERSION')
+getvar = sysconfig.get_config_var
+
+abiflags = getattr(sys, 'abiflags', '')
+libs = ['-lpython' + pyver + abiflags]
+libs += getvar('LIBS').split()
+libs += getvar('SYSLIBS').split()
+# add the prefix/lib/pythonX.Y/config dir, but only if there is no
+# shared library in prefix/lib/.
+if not getvar('Py_ENABLE_SHARED'):
+    libs.insert(0, '-L' + getvar('LIBPL'))
+if not getvar('PYTHONFRAMEWORK'):
+    libs.extend(getvar('LINKFORSHARED').split())
+print(' '.join(libs))
+
+

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -131,10 +131,12 @@ PyObject * ConvertToPython(Napi::Value arg) {
       } else {
         return BuildWrappedJSObject(env, arg);
       }
+    } else if (arg.IsNull() || arg.IsUndefined()) {
+      Py_RETURN_NONE;
     } else {
-      std::cout << "Unknown arg type" << std::endl;
-      // TODO raise an exception here instead
-      return NULL;
+      Napi::String string = arg.ToString();
+      std::cout << "Unknown arg type" << string.Utf8Value() << std::endl;
+      throw Napi::Error::New(arg.Env(), "Unknown arg type");
     }
 }
 

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -98,26 +98,28 @@ PyObject *BuildPyArgs(const Napi::CallbackInfo &args, size_t start_index, size_t
     if (arg.IsNumber()) {
       double num = arg.As<Napi::Number>().ToNumber();
       if (isNapiValueInt(env, arg)) {
-        PyTuple_SetItem(pArgs, i - 1, PyLong_FromLong(num));
+        PyTuple_SetItem(pArgs, i - start_index, PyLong_FromLong(num));
       } else {
-        PyTuple_SetItem(pArgs, i - 1, PyFloat_FromDouble(num));
+        PyTuple_SetItem(pArgs, i - start_index, PyFloat_FromDouble(num));
       }
     } else if (arg.IsString()) {
       std::string str = arg.As<Napi::String>().ToString();
-      PyTuple_SetItem(pArgs, i - 1, PyUnicode_FromString(str.c_str()));
+      PyTuple_SetItem(pArgs, i - start_index, PyUnicode_FromString(str.c_str()));
     } else if (arg.IsBoolean()) {
       long b = arg.As<Napi::Boolean>().ToBoolean();
-      PyTuple_SetItem(pArgs, i - 1, PyBool_FromLong(b));
+      PyTuple_SetItem(pArgs, i - start_index, PyBool_FromLong(b));
       // } else if (arg.IsDate()) {
       //   printf("Dates dont work yet");
       //   // Nan::ThrowError("Dates dont work yet");
       //   throw Napi::Error::New(args.Env(), "Dates dont work  yet");
     } else if (arg.IsArray()) {
       PyObject *list = BuildPyArray(env, arg);
-      PyTuple_SetItem(pArgs, i - 1, list);
+      PyTuple_SetItem(pArgs, i - start_index, list);
     } else if (arg.IsObject()) {
       PyObject *dict = BuildPyDict(env, arg);
-      PyTuple_SetItem(pArgs, i - 1, dict);
+      PyTuple_SetItem(pArgs, i - start_index, dict);
+    } else {
+      std::cout << "Unknown arg type" << std::endl;
     }
   }
 

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -130,7 +130,7 @@ PyObject *BuildPyDict(Napi::Env env, Napi::Value arg) {
 PyObject *BuildWrappedJSObject(Napi::Env env, Napi::Value arg) {
   auto obj = arg.As<Napi::Object>();
   auto keys = obj.GetPropertyNames();
-  PyObject *pyobj = WrappedJSObject_New();
+  PyObject *pyobj = WrappedJSObject_New(env, arg);
   /*for (size_t i = 0; i < keys.Length(); i++) {
     auto key = keys.Get(i);
     std::string keyStr = key.ToString();

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -260,6 +260,9 @@ Napi::Value ConvertFromPython(Napi::Env env, PyObject * pValue) {
     } else if (strcmp(pValue->ob_type->tp_name, "dict") == 0) {
       auto obj = BuildV8Dict(env, pValue);
       result = obj;
+    } else if (strcmp(pValue->ob_type->tp_name, "pynode.WrappedJSObject") == 0) {
+      auto obj = Napi::Value(env, WrappedJSObject_get_napi_value(pValue));
+      result = obj;
     } else {
       auto exp = Napi::External<PyObject>::New(env, pValue);
       auto obj = PyNodeWrappedPythonObject::constructor.New({exp});

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -128,33 +128,7 @@ PyObject *BuildPyDict(Napi::Env env, Napi::Value arg) {
 }
 
 PyObject *BuildWrappedJSObject(Napi::Env env, Napi::Value arg) {
-  auto obj = arg.As<Napi::Object>();
-  auto keys = obj.GetPropertyNames();
   PyObject *pyobj = WrappedJSObject_New(env, arg);
-  /*for (size_t i = 0; i < keys.Length(); i++) {
-    auto key = keys.Get(i);
-    std::string keyStr = key.ToString();
-    Napi::Value val = obj.Get(key);
-    PyObject *pykey = PyBytes_FromString(keyStr.c_str());
-    if (val.IsNumber()) {
-      double num = val.ToNumber();
-      if (isNapiValueInt(env, val)) {
-        PyDict_SetItem(dict, pykey, PyLong_FromLong(num));
-      } else {
-        PyDict_SetItem(dict, pykey, PyFloat_FromDouble(num));
-      }
-    } else if (val.IsString()) {
-      std::string str = val.ToString();
-      PyDict_SetItem(dict, pykey, PyBytes_FromString(str.c_str()));
-    } else if (val.IsArray()) {
-      PyObject *innerList = BuildPyArray(env, val);
-      PyDict_SetItem(dict, pykey, innerList);
-    } else if (val.IsObject()) {
-      PyObject *innerDict = BuildPyDict(env, val);
-      PyDict_SetItem(dict, pykey, innerDict);
-    }
-  }*/
-
   return pyobj;
 }
 

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -267,3 +267,10 @@ Napi::Value ConvertFromPython(Napi::Env env, PyObject * pValue) {
     }
     return result;
 }
+
+extern "C" {
+    napi_value convert_python_to_napi_value(napi_env env, PyObject * obj) {
+        return ConvertFromPython(env, obj);
+    }
+}
+

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -8,6 +8,7 @@ extern "C" {
 #endif
 
 PyObject * convert_napi_value_to_python(napi_env, napi_value);
+napi_value convert_python_to_napi_value(napi_env, PyObject *);
 
 #ifdef __cplusplus
 }

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -1,0 +1,16 @@
+#ifndef PYNODE_HELPERS_H
+#define PYNODE_HELPERS_H
+
+#include <node_api.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+PyObject * convert_napi_value_to_python(napi_env, napi_value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/helpers.hpp
+++ b/src/helpers.hpp
@@ -2,6 +2,7 @@
 #define PYNODE_HELPERS_HPP
 
 #include "napi.h"
+#include "pywrapper.hpp"
 #include <Python.h>
 
 class py_context {
@@ -22,11 +23,12 @@ private:
 // v8 to Python
 PyObject *BuildPyArray(Napi::Env env, Napi::Value arg);
 PyObject *BuildPyDict(Napi::Env env, Napi::Value arg);
-PyObject *BuildPyArgs(const Napi::CallbackInfo &info);
+PyObject *BuildPyArgs(const Napi::CallbackInfo &info, size_t start_index, size_t count);
 
 // Python to v8
 Napi::Array BuildV8Array(Napi::Env env, PyObject *obj);
 Napi::Object BuildV8Dict(Napi::Env env, PyObject *obj);
+Napi::Value ConvertFromPython(Napi::Env env, PyObject *obj);
 
 int Py_GetNumArguments(PyObject *pFunc);
 

--- a/src/helpers.hpp
+++ b/src/helpers.hpp
@@ -3,6 +3,7 @@
 
 #include "napi.h"
 #include "pywrapper.hpp"
+#include "helpers.h"
 #include <Python.h>
 
 class py_context {
@@ -25,6 +26,7 @@ PyObject *BuildPyArray(Napi::Env env, Napi::Value arg);
 PyObject *BuildPyDict(Napi::Env env, Napi::Value arg);
 PyObject *BuildWrappedJSObject(Napi::Env env, Napi::Value arg);
 PyObject *BuildPyArgs(const Napi::CallbackInfo &info, size_t start_index, size_t count);
+PyObject *ConvertToPython(Napi::Value);
 
 // Python to v8
 Napi::Array BuildV8Array(Napi::Env env, PyObject *obj);

--- a/src/helpers.hpp
+++ b/src/helpers.hpp
@@ -23,6 +23,7 @@ private:
 // v8 to Python
 PyObject *BuildPyArray(Napi::Env env, Napi::Value arg);
 PyObject *BuildPyDict(Napi::Env env, Napi::Value arg);
+PyObject *BuildWrappedJSObject(Napi::Env env, Napi::Value arg);
 PyObject *BuildPyArgs(const Napi::CallbackInfo &info, size_t start_index, size_t count);
 
 // Python to v8

--- a/src/jswrapper.c
+++ b/src/jswrapper.c
@@ -19,6 +19,13 @@ WrappedJSObject_dealloc(WrappedJSObject *self)
     Py_TYPE(self)->tp_free((PyObject *) self);
 }
 
+napi_value WrappedJSObject_get_napi_value(PyObject *_self) {
+    WrappedJSObject *self = (WrappedJSObject *)_self;
+    napi_value wrapped;
+    napi_get_reference_value(self->env, self->object_reference, &wrapped);
+    return wrapped;
+}
+
 static void
 WrappedJSObject_assign_napi_value(WrappedJSObject *self, napi_env env, napi_value value) {
     self->env = env;

--- a/src/jswrapper.c
+++ b/src/jswrapper.c
@@ -66,6 +66,31 @@ static PyMethodDef WrappedJSObject_methods[] = {
     {NULL}, /* Sentinel */
 };
 
+static PyObject *
+WrappedJSObject_getattro(PyObject *_self, PyObject *attr)
+{
+    WrappedJSObject *self = (WrappedJSObject*)_self;
+    napi_value wrapped;
+    bool hasattr;
+    const char * utf8name = PyUnicode_AsUTF8(attr);
+    napi_value result;
+    napi_get_reference_value(self->env, self->object_reference, &wrapped);
+    napi_has_named_property(self->env, wrapped, utf8name, &hasattr);
+    if (hasattr) {
+        napi_get_named_property(self->env, wrapped, utf8name, &result);
+        printf("got property\n");// TODO convert to Python
+    }
+    PyErr_SetObject(PyExc_AttributeError, attr);
+    return NULL;
+}
+
+static PyObject *
+WrappedJSObject_call(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    //printf("__call__ called\n");
+    Py_RETURN_NONE;
+}
+
 static PyTypeObject WrappedJSType = {
     PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "pynode.WrappedJSObject",
@@ -78,6 +103,8 @@ static PyTypeObject WrappedJSType = {
     .tp_dealloc = (destructor) WrappedJSObject_dealloc,
     .tp_members = WrappedJSObject_members,
     .tp_methods = WrappedJSObject_methods,
+    .tp_call = WrappedJSObject_call,
+    .tp_getattro = WrappedJSObject_getattro,
 };
 
 PyObject *WrappedJSObject_New(napi_env env, napi_value value) {

--- a/src/jswrapper.c
+++ b/src/jswrapper.c
@@ -79,6 +79,10 @@ WrappedJSObject_getattro(PyObject *_self, PyObject *attr)
     if (hasattr) {
         napi_get_named_property(self->env, wrapped, utf8name, &result);
         printf("got property\n");// TODO convert to Python
+        PyObject *pyval = convert_napi_value_to_python(self->env, result);
+        if (pyval != NULL) {
+            return pyval;
+        }
     }
     PyErr_SetObject(PyExc_AttributeError, attr);
     return NULL;

--- a/src/jswrapper.c
+++ b/src/jswrapper.c
@@ -1,0 +1,100 @@
+#define PY_SSIZE_T_CLEAN
+#include "jswrapper.h"
+#include <structmember.h>
+
+typedef struct {
+    PyObject_HEAD
+    /* Type-specific fields go here. */
+    void * wrapped_object;
+} WrappedJSObject;
+
+static void
+WrappedJSObject_dealloc(WrappedJSObject *self)
+{
+    // TODO - decref wrapped_object
+    Py_TYPE(self)->tp_free((PyObject *) self);
+}
+
+static PyObject *
+WrappedJSObject_new(PyTypeObject *type, PyObject *args, PyObject *kwds) {
+    WrappedJSObject *self;
+    self = (WrappedJSObject *) type->tp_alloc(type, 0);
+    if (self != NULL) {
+        self->wrapped_object = NULL;
+    }
+    return (PyObject *) self;
+}
+
+static int
+WrappedJSObject_init(WrappedJSObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!PyArg_ParseTuple(args, ""))
+        return -1;
+    return 0;
+}
+
+static PyMemberDef WrappedJSObject_members[] = {
+    {NULL}  /* Sentinel */
+};
+
+static PyObject *
+WrappedJSObject_something(WrappedJSObject *self, PyObject *unused)
+{
+    //self->state++;
+    //return PyLong_FromLong(self->state);
+    return PyLong_FromLong(47.0);
+}
+
+static PyMethodDef WrappedJSObject_methods[] = {
+    {"something", (PyCFunction) WrappedJSObject_something, METH_NOARGS,
+     PyDoc_STR("Do something?")},
+    {NULL}, /* Sentinel */
+};
+
+static PyTypeObject WrappedJSType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "pynode.WrappedJSObject",
+    .tp_doc = "A JavaScript object",
+    .tp_basicsize = sizeof(WrappedJSObject),
+    .tp_itemsize = 0,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .tp_new = WrappedJSObject_new,
+    .tp_init = (initproc) WrappedJSObject_init,
+    .tp_dealloc = (destructor) WrappedJSObject_dealloc,
+    .tp_members = WrappedJSObject_members,
+    .tp_methods = WrappedJSObject_methods,
+};
+
+PyObject *WrappedJSObject_New() {
+    WrappedJSObject *obj = PyObject_NEW(WrappedJSObject, &WrappedJSType);
+    printf("Created new object\n");
+    return (PyObject *)obj;
+}
+
+static PyModuleDef pynodemodule = {
+    PyModuleDef_HEAD_INIT,
+    .m_name = "pynode",
+    .m_doc = "Python <3 JavaScript.",
+    .m_size = -1,
+};
+
+PyMODINIT_FUNC
+PyInit_jswrapper(void)
+{
+    PyObject *m;
+    if (PyType_Ready(&WrappedJSType) < 0)
+        return NULL;
+
+    m = PyModule_Create(&pynodemodule);
+    if (m == NULL)
+        return NULL;
+
+    Py_INCREF(&WrappedJSType);
+    if (PyModule_AddObject(m, "WrappedJSObject", (PyObject *) &WrappedJSType) < 0) {
+        Py_DECREF(&WrappedJSType);
+        Py_DECREF(m);
+        return NULL;
+    }
+
+    return m;
+}

--- a/src/jswrapper.h
+++ b/src/jswrapper.h
@@ -2,13 +2,14 @@
 #define PYNODE_JSWRAPPER_HPP
 
 #include <Python.h>
+#include <node_api.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 PyMODINIT_FUNC PyInit_jswrapper(void);
-PyObject *WrappedJSObject_New(void);
+PyObject *WrappedJSObject_New(napi_env, napi_value);
 
 #ifdef __cplusplus
 }

--- a/src/jswrapper.h
+++ b/src/jswrapper.h
@@ -3,6 +3,7 @@
 
 #include <Python.h>
 #include <node_api.h>
+#include "helpers.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/jswrapper.h
+++ b/src/jswrapper.h
@@ -1,0 +1,17 @@
+#ifndef PYNODE_JSWRAPPER_HPP
+#define PYNODE_JSWRAPPER_HPP
+
+#include <Python.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+PyMODINIT_FUNC PyInit_jswrapper(void);
+PyObject *WrappedJSObject_New(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/jswrapper.h
+++ b/src/jswrapper.h
@@ -11,6 +11,7 @@ extern "C" {
 
 PyMODINIT_FUNC PyInit_jswrapper(void);
 PyObject *WrappedJSObject_New(napi_env, napi_value);
+napi_value WrappedJSObject_get_napi_value(PyObject *);
 
 #ifdef __cplusplus
 }

--- a/src/pynode.cpp
+++ b/src/pynode.cpp
@@ -31,6 +31,18 @@ Napi::Value StartInterpreter(const Napi::CallbackInfo &info) {
   if (threadsInitialized == 0)
     PyEval_InitThreads();
 
+  /* Load PyNode's own module into Python. This makes WrappedJSObject instances
+     behave better (eg, having attributes) */
+  PyObject *pName;
+  pName = PyUnicode_DecodeFSDefault("pynode");
+  pModule = PyImport_Import(pName);
+  Py_DECREF(pName);
+  if (pModule == NULL) {
+    PyErr_Print();
+    Napi::Error::New(env, "Failed to load the pynode module into the Python interpreter")
+        .ThrowAsJavaScriptException();
+  }
+
   return env.Null();
 }
 

--- a/src/pynode.cpp
+++ b/src/pynode.cpp
@@ -4,6 +4,7 @@
 #endif
 #include "helpers.hpp"
 #include "worker.hpp"
+#include "pywrapper.hpp"
 #include <iostream>
 
 PyObject *pModule;
@@ -203,6 +204,8 @@ Napi::Object PyNodeInit(Napi::Env env, Napi::Object exports) {
   exports.Set(Napi::String::New(env, "eval"), Napi::Function::New(env, Eval));
 
   exports.Set(Napi::String::New(env, "call"), Napi::Function::New(env, Call));
+
+  PyNodeWrappedPythonObject::Init(env, exports);
 
   return exports;
 }

--- a/src/pynode.cpp
+++ b/src/pynode.cpp
@@ -5,6 +5,7 @@
 #include "helpers.hpp"
 #include "worker.hpp"
 #include "pywrapper.hpp"
+#include "jswrapper.h"
 #include <iostream>
 
 PyObject *pModule;
@@ -18,10 +19,13 @@ Napi::Value StartInterpreter(const Napi::CallbackInfo &info) {
     mbstowcs(&path[0], pathString.c_str(), pathString.length());
     Py_SetPath(path.c_str());
   }
+  
+  PyImport_AppendInittab("pynode", &PyInit_jswrapper);
 
   int isInitialized = Py_IsInitialized();
-  if (isInitialized == 0)
+  if (isInitialized == 0) {
     Py_Initialize();
+  }
 
   int threadsInitialized = PyEval_ThreadsInitialized();
   if (threadsInitialized == 0)

--- a/src/pynode.cpp
+++ b/src/pynode.cpp
@@ -168,9 +168,9 @@ Napi::Value Call(const Napi::CallbackInfo &info) {
         return env.Null();
       }
 
-      pArgs = BuildPyArgs(info);
+      // Arguments length minus 2: one for function name, one for js callback
+      pArgs = BuildPyArgs(info, 1, info.Length() - 2);
     } else {
-      std::cerr << "nope" << std::endl;
       Napi::Error::New(env,
                        "Could not find function name / function not callable")
           .ThrowAsJavaScriptException();

--- a/src/pywrapper.cpp
+++ b/src/pywrapper.cpp
@@ -36,8 +36,6 @@ Napi::FunctionReference PyNodeWrappedPythonObject::constructor;
 Napi::Value PyNodeWrappedPythonObject::GetAttr(const Napi::CallbackInfo &info){
     Napi::Env env = info.Env();
     std::string attrname = info[0].As<Napi::String>().ToString();
-    std::cout << "getting attr " + attrname << std::endl;
-    std::cout << "this is " << this->_value << std::endl;
     PyObject * attr = PyObject_GetAttrString(this->_value, attrname.c_str());
     if (attr == NULL) {
         std::string error("Attribute " + attrname + " not found.");
@@ -61,7 +59,11 @@ Napi::Value PyNodeWrappedPythonObject::Call(const Napi::CallbackInfo &info){
     Py_DECREF(pArgs);
     PyObject *error_occurred = PyErr_Occurred();
     if (error_occurred != NULL) {
-        // TODO - handle error
+        // TODO - get the traceback string into Javascript
+        std::string error("A Python error occurred.");
+        PyErr_Print();
+        Napi::Error::New(env, error).ThrowAsJavaScriptException();
+        return env.Null();
     }
     Napi::Value returnval = ConvertFromPython(env, pReturnValue);
     Py_DECREF(pReturnValue);

--- a/src/pywrapper.cpp
+++ b/src/pywrapper.cpp
@@ -1,11 +1,13 @@
 #include "pywrapper.hpp"
 #include <napi.h>
+#include <iostream>
 
 Napi::Object PyNodeWrappedPythonObject::Init(Napi::Env env, Napi::Object exports) {
     // This method is used to hook the accessor and method callbacks
     Napi::Function func = DefineClass(env, "PyNodeWrappedPythonObject", {
-        InstanceMethod("GetValue", &PyNodeWrappedPythonObject::GetValue),
-        InstanceMethod("SetValue", &PyNodeWrappedPythonObject::SetValue)
+        InstanceMethod("call", &PyNodeWrappedPythonObject::Call),
+        InstanceMethod("get", &PyNodeWrappedPythonObject::GetAttr),
+        InstanceMethod("repr", &PyNodeWrappedPythonObject::Repr)
     });
 
     // Create a peristent reference to the class constructor. This will allow
@@ -25,20 +27,58 @@ PyNodeWrappedPythonObject::PyNodeWrappedPythonObject(const Napi::CallbackInfo &i
     // ...
     PyObject * value = info[0].As<Napi::External<PyObject>>().Data();
     this->_value = value;
+    Py_INCREF(this->_value);
+    // TODO - Py_DECREF in destructor
 }
 
 Napi::FunctionReference PyNodeWrappedPythonObject::constructor;
 
-Napi::Value PyNodeWrappedPythonObject::GetValue(const Napi::CallbackInfo &info){
+Napi::Value PyNodeWrappedPythonObject::GetAttr(const Napi::CallbackInfo &info){
     Napi::Env env = info.Env();
-    return Napi::Number::New(env, 0.0);
+    std::string attrname = info[0].As<Napi::String>().ToString();
+    std::cout << "getting attr " + attrname << std::endl;
+    std::cout << "this is " << this->_value << std::endl;
+    PyObject * attr = PyObject_GetAttrString(this->_value, attrname.c_str());
+    if (attr == NULL) {
+        std::string error("Attribute " + attrname + " not found.");
+        Napi::Error::New(env, error).ThrowAsJavaScriptException();
+        return env.Null();
+    }
+    Napi::Value returnval = ConvertFromPython(env, attr);
+    return returnval;
 }
 
-Napi::Value PyNodeWrappedPythonObject::SetValue(const Napi::CallbackInfo &info){
-    //Napi::Env env = info.Env();
-    // ...
-    PyObject * value = info[0].As<Napi::External<PyObject>>().Data();
-    this->_value = value;
-    return this->GetValue(info);
+Napi::Value PyNodeWrappedPythonObject::Call(const Napi::CallbackInfo &info){
+    Napi::Env env = info.Env();
+    int callable = PyCallable_Check(this->_value);
+    if (! callable) {
+        std::string error("This Python object is not callable.");
+        Napi::Error::New(env, error).ThrowAsJavaScriptException();
+        return env.Null();
+    }
+    PyObject * pArgs = BuildPyArgs(info, 0, info.Length());
+    PyObject * pReturnValue = PyObject_Call(this->_value, pArgs, NULL);
+    Py_DECREF(pArgs);
+    PyObject *error_occurred = PyErr_Occurred();
+    if (error_occurred != NULL) {
+        // TODO - handle error
+    }
+    Napi::Value returnval = ConvertFromPython(env, pReturnValue);
+    Py_DECREF(pReturnValue);
+    return returnval;
+}
+
+Napi::Value PyNodeWrappedPythonObject::Repr(const Napi::CallbackInfo &info){
+    Napi::Env env = info.Env();
+    std::string attrname = info[0].As<Napi::String>().ToString();
+    PyObject * repr = PyObject_Repr(this->_value);
+    if (repr == NULL) {
+        std::string error("repr() failed.");
+        Napi::Error::New(env, error).ThrowAsJavaScriptException();
+        return env.Null();
+    }
+    const char * repr_c = PyUnicode_AsUTF8(repr);
+    Napi::Value result = Napi::String::New(env, repr_c); // (Napi takes ownership of repr_c)
+    return result;
 }
 

--- a/src/pywrapper.cpp
+++ b/src/pywrapper.cpp
@@ -34,7 +34,7 @@ PyNodeWrappedPythonObject::PyNodeWrappedPythonObject(const Napi::CallbackInfo &i
 Napi::FunctionReference PyNodeWrappedPythonObject::constructor;
 
 Napi::Value PyNodeWrappedPythonObject::GetAttr(const Napi::CallbackInfo &info){
-    py_context ctx;
+    py_ensure_gil ctx;
     Napi::Env env = info.Env();
     std::string attrname = info[0].As<Napi::String>().ToString();
     PyObject * attr = PyObject_GetAttrString(this->_value, attrname.c_str());
@@ -48,7 +48,7 @@ Napi::Value PyNodeWrappedPythonObject::GetAttr(const Napi::CallbackInfo &info){
 }
 
 Napi::Value PyNodeWrappedPythonObject::Call(const Napi::CallbackInfo &info){
-    py_context ctx;
+    py_ensure_gil ctx;
     Napi::Env env = info.Env();
     int callable = PyCallable_Check(this->_value);
     if (! callable) {
@@ -73,7 +73,7 @@ Napi::Value PyNodeWrappedPythonObject::Call(const Napi::CallbackInfo &info){
 }
 
 Napi::Value PyNodeWrappedPythonObject::Repr(const Napi::CallbackInfo &info){
-    py_context ctx;
+    py_ensure_gil ctx;
     Napi::Env env = info.Env();
     std::string attrname = info[0].As<Napi::String>().ToString();
     PyObject * repr = PyObject_Repr(this->_value);

--- a/src/pywrapper.cpp
+++ b/src/pywrapper.cpp
@@ -34,6 +34,7 @@ PyNodeWrappedPythonObject::PyNodeWrappedPythonObject(const Napi::CallbackInfo &i
 Napi::FunctionReference PyNodeWrappedPythonObject::constructor;
 
 Napi::Value PyNodeWrappedPythonObject::GetAttr(const Napi::CallbackInfo &info){
+    py_context ctx;
     Napi::Env env = info.Env();
     std::string attrname = info[0].As<Napi::String>().ToString();
     PyObject * attr = PyObject_GetAttrString(this->_value, attrname.c_str());
@@ -47,6 +48,7 @@ Napi::Value PyNodeWrappedPythonObject::GetAttr(const Napi::CallbackInfo &info){
 }
 
 Napi::Value PyNodeWrappedPythonObject::Call(const Napi::CallbackInfo &info){
+    py_context ctx;
     Napi::Env env = info.Env();
     int callable = PyCallable_Check(this->_value);
     if (! callable) {
@@ -71,6 +73,7 @@ Napi::Value PyNodeWrappedPythonObject::Call(const Napi::CallbackInfo &info){
 }
 
 Napi::Value PyNodeWrappedPythonObject::Repr(const Napi::CallbackInfo &info){
+    py_context ctx;
     Napi::Env env = info.Env();
     std::string attrname = info[0].As<Napi::String>().ToString();
     PyObject * repr = PyObject_Repr(this->_value);

--- a/src/pywrapper.cpp
+++ b/src/pywrapper.cpp
@@ -1,0 +1,44 @@
+#include "pywrapper.hpp"
+#include <napi.h>
+
+Napi::Object PyNodeWrappedPythonObject::Init(Napi::Env env, Napi::Object exports) {
+    // This method is used to hook the accessor and method callbacks
+    Napi::Function func = DefineClass(env, "PyNodeWrappedPythonObject", {
+        InstanceMethod("GetValue", &PyNodeWrappedPythonObject::GetValue),
+        InstanceMethod("SetValue", &PyNodeWrappedPythonObject::SetValue)
+    });
+
+    // Create a peristent reference to the class constructor. This will allow
+    // a function called on a class prototype and a function
+    // called on instance of a class to be distinguished from each other.
+    constructor = Napi::Persistent(func);
+    // Call the SuppressDestruct() method on the static data prevent the calling
+    // to this destructor to reset the reference when the environment is no longer
+    // available.
+    constructor.SuppressDestruct();
+    exports.Set("PyNodeWrappedPythonObject", func);
+    return exports;
+}
+
+PyNodeWrappedPythonObject::PyNodeWrappedPythonObject(const Napi::CallbackInfo &info) : Napi::ObjectWrap<PyNodeWrappedPythonObject>(info) {
+    //Napi::Env env = info.Env();
+    // ...
+    PyObject * value = info[0].As<Napi::External<PyObject>>().Data();
+    this->_value = value;
+}
+
+Napi::FunctionReference PyNodeWrappedPythonObject::constructor;
+
+Napi::Value PyNodeWrappedPythonObject::GetValue(const Napi::CallbackInfo &info){
+    Napi::Env env = info.Env();
+    return Napi::Number::New(env, 0.0);
+}
+
+Napi::Value PyNodeWrappedPythonObject::SetValue(const Napi::CallbackInfo &info){
+    //Napi::Env env = info.Env();
+    // ...
+    PyObject * value = info[0].As<Napi::External<PyObject>>().Data();
+    this->_value = value;
+    return this->GetValue(info);
+}
+

--- a/src/pywrapper.hpp
+++ b/src/pywrapper.hpp
@@ -10,8 +10,9 @@ class PyNodeWrappedPythonObject : public Napi::ObjectWrap<PyNodeWrappedPythonObj
     static Napi::Object Init(Napi::Env env, Napi::Object exports);
     PyNodeWrappedPythonObject(const Napi::CallbackInfo &info);
     static Napi::FunctionReference constructor;
-    Napi::Value GetValue(const Napi::CallbackInfo &info);
-    Napi::Value SetValue(const Napi::CallbackInfo &info);
+    Napi::Value Call(const Napi::CallbackInfo &info);
+    Napi::Value GetAttr(const Napi::CallbackInfo &info);
+    Napi::Value Repr(const Napi::CallbackInfo &info);
 
   private:
     PyObject * _value;

--- a/src/pywrapper.hpp
+++ b/src/pywrapper.hpp
@@ -1,0 +1,21 @@
+#ifndef PYNODE_PYWRAPPER_HPP
+#define PYNODE_PYWRAPPER_HPP
+
+#include "Python.h"
+#include "helpers.hpp"
+#include "napi.h"
+
+class PyNodeWrappedPythonObject : public Napi::ObjectWrap<PyNodeWrappedPythonObject> {
+  public:
+    static Napi::Object Init(Napi::Env env, Napi::Object exports);
+    PyNodeWrappedPythonObject(const Napi::CallbackInfo &info);
+    static Napi::FunctionReference constructor;
+    Napi::Value GetValue(const Napi::CallbackInfo &info);
+    Napi::Value SetValue(const Napi::CallbackInfo &info);
+
+  private:
+    PyObject * _value;
+};
+
+#endif
+

--- a/src/pywrapper.hpp
+++ b/src/pywrapper.hpp
@@ -13,6 +13,7 @@ class PyNodeWrappedPythonObject : public Napi::ObjectWrap<PyNodeWrappedPythonObj
     Napi::Value Call(const Napi::CallbackInfo &info);
     Napi::Value GetAttr(const Napi::CallbackInfo &info);
     Napi::Value Repr(const Napi::CallbackInfo &info);
+    PyObject * getValue() { return _value; };
 
   private:
     PyObject * _value;

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -53,35 +53,7 @@ void PyNodeWorker::OnOK() {
   std::vector<Napi::Value> result = {Env().Null(), Env().Null()};
 
   if (pValue != NULL) {
-    if (strcmp(pValue->ob_type->tp_name, "NoneType") == 0) {
-      // leave as null
-    } else if (strcmp(pValue->ob_type->tp_name, "bool") == 0) {
-      bool b = PyObject_IsTrue(pValue);
-      result[1] = Napi::Boolean::New(Env(), b);
-    } else if (strcmp(pValue->ob_type->tp_name, "int") == 0) {
-      double d = PyLong_AsDouble(pValue);
-      result[1] = Napi::Number::New(Env(), d);
-    } else if (strcmp(pValue->ob_type->tp_name, "float") == 0) {
-      double d = PyFloat_AsDouble(pValue);
-      result[1] = Napi::Number::New(Env(), d);
-    } else if (strcmp(pValue->ob_type->tp_name, "bytes") == 0) {
-      auto str = Napi::String::New(Env(), PyBytes_AsString(pValue));
-      result[1] = str;
-    } else if (strcmp(pValue->ob_type->tp_name, "str") == 0) {
-      auto str = Napi::String::New(Env(), PyUnicode_AsUTF8(pValue));
-      result[1] = str;
-    } else if (strcmp(pValue->ob_type->tp_name, "list") == 0) {
-      auto arr = BuildV8Array(Env(), pValue);
-      result[1] = arr;
-    } else if (strcmp(pValue->ob_type->tp_name, "dict") == 0) {
-      auto obj = BuildV8Dict(Env(), pValue);
-      result[1] = obj;
-    } else {
-      auto exp = Napi::External<PyObject>::New(Env(), pValue);
-      auto obj = PyNodeWrappedPythonObject::constructor.New({exp});
-      result[1] = obj;
-    }
-
+    result[1] = ConvertFromPython(Env(), pValue);
     Py_DECREF(pValue);
   } else {
     std::string error;

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -77,11 +77,9 @@ void PyNodeWorker::OnOK() {
       auto obj = BuildV8Dict(Env(), pValue);
       result[1] = obj;
     } else {
-      std::string errMsg =
-          std::string("Unsupported type returned (") +
-          pValue->ob_type->tp_name +
-          std::string("), only pure Python types are supported.");
-      result[0] = Napi::String::New(Env(), errMsg);
+      auto exp = Napi::External<PyObject>::New(Env(), pValue);
+      auto obj = PyNodeWrappedPythonObject::constructor.New({exp});
+      result[1] = obj;
     }
 
     Py_DECREF(pValue);

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -10,7 +10,7 @@ PyNodeWorker::~PyNodeWorker(){};
 
 void PyNodeWorker::Execute() {
   {
-    py_context ctx;
+    py_thread_context ctx;
 
     pValue = PyObject_CallObject(pFunc, pyArgs);
     Py_DECREF(pyArgs);
@@ -47,7 +47,7 @@ void PyNodeWorker::Execute() {
 }
 
 void PyNodeWorker::OnOK() {
-  py_context ctx;
+  py_thread_context ctx;
   Napi::HandleScope scope(Env());
 
   std::vector<Napi::Value> result = {Env().Null(), Env().Null()};

--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -2,6 +2,7 @@
 #define PYNODE_WORKER_HPP
 
 #include "Python.h"
+#include "pywrapper.hpp"
 #include "helpers.hpp"
 #include "napi.h"
 


### PR DESCRIPTION
Hi! I'm filing this pull request more as a heads-up than something I'm expecting will get merged, but thought you might like to know about its existence in case it's of any use to you, and to gauge interest before polishing it any further. (This was originally developed for a prototype project - https://github.com/iguanaonmystack/traingame-bot - and it works well enough for that, but well, prototypes are prototypes.)

This branch adds a new API, which I've dubbed the Full Object API for lack of a better idea, that provides access to arbitrary Python objects from JavaScript, and to arbitrary JavaScript objects from Python. I've updated README.md with a full example, or the prototype project linked above is essentially a full demo application.

The new API primarily provides:
* the ability to call into, and get attributes from, JS objects from Python, and Python objects from JS. Primitives are still converted to their nearest JS/Python equivalents, but anything that looks like it's an instance of a user-defined class (or some other non-primitive value) is returned wrapped by a C Extension type (for Python) or a NAPI ObjectWrap (for JS). It's pretty seamless for JS inside Python. The JS wrapper for Python objects is a little more clunky but works well enough;
* the ability to import more than one Python module at a time (using `import` rather than `importFile`). The imported modules are returned themselves as wrapped Python objects using the same mechanics as any other wrapped Python objects (below), so don't require any additional top-level functions to interact with.

None of the current PyNode functionality is replaced or altered.

I realise this deviates from PyNode's conventions in that everything is synchronous (ie, the function returns its result within the current thread, without a callback, deferred, etc). I'm relatively new to JavaScript (or at least, the last ten years of JavaScript) so perhaps I'm missing a trick here, but I was working on the basis that most existing Python modules one might want to call into, and/or provide callbacks for, will be expecting a synchronous API (ignoring for now Python's newish async/await syntax, which I haven't seen in the wild very often.)